### PR TITLE
Refactor GitRemote URL handling for Codecrafters servers

### DIFF
--- a/internal/utils/git_remote.go
+++ b/internal/utils/git_remote.go
@@ -29,17 +29,19 @@ func (r GitRemote) CodecraftersServerURL() string {
 		return "https://backend-staging.codecrafters.io"
 	}
 
-	devServerRegex := regexp.MustCompile("codecrafters-([^-]*)-git.ngrok.io")
+	ngrokDevServerRegex := regexp.MustCompile(`cc-([\w-]+).ngrok.io`)
 
-	if devServerRegex.MatchString(r.Url) {
-		replacedUrl := regexp.MustCompile("-git").ReplaceAllString(r.Url, "")
-		replacedUrl = regexp.MustCompile("ngrok.io/.*").ReplaceAllString(replacedUrl, "ngrok.io")
+	// cc-paul-git.ngrok.io -> paul-backend.ccdev.dev
+	if ngrokDevServerRegex.MatchString(r.Url) {
+		replacedUrl := regexp.MustCompile(`\-git.ngrok.io/.*`).ReplaceAllString(r.Url, "-backend.ccdev.dev") // cc-paul-backend.ccdev.dev
+		replacedUrl = regexp.MustCompile("cc-").ReplaceAllString(replacedUrl, "")                            // paul-backend.ccdev.dev
 		return replacedUrl
 	}
 
-	newDevServerRegex := regexp.MustCompile("(.*)-git.ccdev.dev")
+	cloudflareDevServerRegex := regexp.MustCompile("(.*)-git.ccdev.dev")
 
-	if newDevServerRegex.MatchString(r.Url) {
+	// cc-paul-git.ccdev.dev -> paul.ccdev.dev
+	if cloudflareDevServerRegex.MatchString(r.Url) {
 		replacedUrl := regexp.MustCompile("-git").ReplaceAllString(r.Url, "-backend")
 		replacedUrl = regexp.MustCompile("ccdev.dev/.*").ReplaceAllString(replacedUrl, "ccdev.dev")
 		return replacedUrl


### PR DESCRIPTION
The GitRemote struct in git_remote.go has been refactored to handle Codecrafters server URLs more efficiently. The changes include:

 • Updated regular expressions to match ngrok and cloudflare server URLs.
 • Replaced parts of the URL to generate the correct server URL.
 • Removed unnecessary replacements and simplifications.

These changes improve the handling of Codecrafters server URLs, ensuring that the correct server URL is returned based on the provided GitRemote
URL.
