### PR TITLE
Refactor submission creation in submit.go and test.go

### DIFF
--- a/internal/commands/submit.go
+++ b/internal/commands/submit.go
@@ -91,7 +91,7 @@ func SubmitCommand(ctx context.Context) (err error) {
 
 	logger.Debug().Msgf("creating submission for %s", commitSha)
 
-	createSubmissionResponse, err := codecraftersClient.CreateSubmission(codecraftersRemote.CodecraftersRepositoryId(), commitSha)
+	createSubmissionResponse, err := codecraftersClient.CreateSubmission(codecraftersRemote.CodecraftersRepositoryId(), commitSha, "submit")
 	if err != nil {
 		return fmt.Errorf("create submission: %w", err)
 	}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -105,7 +105,7 @@ func TestCommand(ctx context.Context) (err error) {
 
 	logger.Debug().Msgf("creating submission for %s", tempCommitSha)
 
-	createSubmissionResponse, err := codecraftersClient.CreateSubmission(codecraftersRemote.CodecraftersRepositoryId(), tempCommitSha)
+	createSubmissionResponse, err := codecraftersClient.CreateSubmission(codecraftersRemote.CodecraftersRepositoryId(), tempCommitSha, "test")
 	if err != nil {
 		return fmt.Errorf("create submission: %w", err)
 	}

--- a/internal/utils/codecrafters_client.go
+++ b/internal/utils/codecrafters_client.go
@@ -88,12 +88,12 @@ func (c CodecraftersClient) headers() map[string]string {
 	}
 }
 
-func (c CodecraftersClient) CreateSubmission(repositoryId string, commitSha string) (CreateSubmissionResponse, error) {
+func (c CodecraftersClient) CreateSubmission(repositoryId string, commitSha string, command string) (CreateSubmissionResponse, error) {
 	response, err := grequests.Post(c.ServerUrl+"/services/cli/create_submission", &grequests.RequestOptions{
 		JSON: map[string]interface{}{
-			"repository_id":       repositoryId,
-			"commit_sha":          commitSha,
-			"should_auto_advance": false,
+			"repository_id": repositoryId,
+			"commit_sha":    commitSha,
+			"command":       command,
 		},
 		Headers: c.headers(),
 	})


### PR DESCRIPTION
This commit refactors the submission creation in submit.go and test.go files. It adds a new parameter command to the CreateSubmission function in
codecrafters_client.go file. The command parameter is used to specify the type of submission, either "submit" or "test". This change allows for better code
organization and separation of concerns.

Commit message: "Refactor submission creation in submit.go and test.go"
