### PR TITLE
Fetching latest version from the repository and showing an update message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,21 @@
 
 set -eu
 
+# Ensure curl is installed before fetching the version
+if ! command -v curl >/dev/null; then
+  echo "error: 'curl' is required to fetch the latest version information."
+  exit 1
+fi
+
 # Allow overriding the version
-VERSION=${CODECRAFTERS_CLI_VERSION:-$(curl -s https://api.github.com/repos/codecrafters-io/cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')}
+VERSION=${CODECRAFTERS_CLI_VERSION:-$(curl -s https://api.github.com/repos/codecrafters-io/cli/releases/latest \
+    | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')}
+
+# Fail early if we couldn’t extract a version
+if [ -z "$VERSION" ]; then
+  echo "error: failed to fetch the latest release tag from GitHub."
+  exit 1
+fi
 PLATFORM=$(uname -s)
 ARCH=$(uname -m)
 


### PR DESCRIPTION
The title says most of what I have done.

I changed the install script so it fetches the latest version tag directly from GitHub, instead of defaulting to v35, which is now old.

As a bonus, I also changed the script so it says "updating Codecrafters" instead of "installing" if it finds that the **INSTALL_DIR** is already there.

Just a small little QOL fix, shouldn't conflict with anything you are doing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The installation script now automatically selects the latest available version if no version is specified.
  - Installation messages now clearly indicate whether the action is a fresh install or an update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->