### PR TITLE
Tweak message when buildpack is already up to date

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -189,8 +189,8 @@ func pushBranchToRemote(tmpDir string, remoteName string) error {
 
 func wrapError(err error, output []byte, msg string) error {
 	if _, ok := err.(*exec.ExitError); ok {
-		return fmt.Errorf("add all files: %s", output)
+		return fmt.Errorf("%s: %s. Error: %w", msg, output, err)
 	}
 
-	return fmt.Errorf("add all files: %w", err)
+	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/internal/commands/update_buildpack.go
+++ b/internal/commands/update_buildpack.go
@@ -92,6 +92,7 @@ func UpdateBuildpackCommand(ctx context.Context) (err error) {
 
 	if currentBuildpackSlug == latestBuildpack.Slug {
 		fmt.Printf("Buildpack is already up to date (%s)\n", currentBuildpackSlug)
+		fmt.Println("Let us know at hello@codecrafters.io if you’d like us to upgrade the supported buildpack version.")
 		return nil
 	}
 


### PR DESCRIPTION
Prompt users to let us know if our supported buildpack version is outdated:

<img width="1804" height="562" alt="image" src="https://github.com/user-attachments/assets/d61a2936-84a8-40b2-8279-7d06461fc864" />

---

Fixing a minor test display bug as well.