### PR TITLE
Make Test-Path more robust

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -40,7 +40,7 @@ try {
 
     tar -xzf $TarGzPath -C $TempDir
 
-    if (-not (Test-Path $InstallDir)) {
+    if (-not (Test-Path -LiteralPath $InstallDir)) {
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     }
 
@@ -62,7 +62,11 @@ try {
     Write-Host ""
 } finally {
     # Cleanup
-    if (Test-Path $TempDir) {
-        Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $TempDir) {
+        try {
+            Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction Stop
+        } catch {
+            Write-Host "Warning: couldn't clean up temporary folder: $TempDir" -ForegroundColor Yellow
+        }
     }
 }


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3244692401/11524?viewId=8414074

Without -LiteralPath, this error can happen:

<img width="1594" height="1164" alt="image" src="https://github.com/user-attachments/assets/109fd706-85d2-4727-a877-2ff54d24053a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks Windows installer script path checks and temp cleanup behavior, with minimal impact beyond more reliable installs and slightly different cleanup failure handling.
> 
> **Overview**
> Improves the Windows `install.ps1` script’s robustness by switching `Test-Path` calls to `-LiteralPath` for both the install directory and temp directory checks, avoiding failures with special characters in paths.
> 
> Also hardens temp-folder cleanup by wrapping `Remove-Item` in a `try/catch`, using `-ErrorAction Stop`, and emitting a warning if cleanup fails instead of silently ignoring errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3716686c935d0ffc24ef9c2fa4ea5bb07580da9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->