### PR TITLE
CC-2184: Clean up err msg in GetRepositoryDir

### DIFF
--- a/internal/utils/repository_dir.go
+++ b/internal/utils/repository_dir.go
@@ -19,10 +19,8 @@ func GetRepositoryDir() (string, error) {
 	if err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
 			if regexp.MustCompile("not a git repository").Match(outputBytes) {
-				fmt.Fprintf(os.Stderr, "The current directory is not within a Git repository.\n")
-				fmt.Fprintf(os.Stderr, "Please run this command from within your CodeCrafters Git repository.\n")
-
-				return "", errors.New("used not in a repository")
+				return "", errors.New(`Error: The current directory is not within a Git repository.
+Please run this command from within your CodeCrafters Git repository.`)
 			}
 		}
 


### PR DESCRIPTION
**Before:**

<img width="1358" height="308" alt="image" src="https://github.com/user-attachments/assets/eb983351-efb5-442e-978f-891d6c305a59" />

---

**After:**

<img width="1440" height="518" alt="image" src="https://github.com/user-attachments/assets/d6bd4622-9d5a-45cb-99b5-5ea1e382a59c" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the user-facing error returned when `git rev-parse` indicates the directory is not a Git repo; no functional logic changes beyond messaging.
> 
> **Overview**
> Improves the “not a git repository” handling in `GetRepositoryDir()` by replacing multi-line `stderr` prints plus a generic error with a single returned multi-line error message that guides the user to run the command inside a CodeCrafters Git repository.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e57e243e0630be0bb49f51214b5d904cf01bde1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->