### PR TITLE
feat: custom commit message on submit

### DIFF
--- a/cmd/codecrafters/main.go
+++ b/cmd/codecrafters/main.go
@@ -82,7 +82,23 @@ func run() error {
 
 		return commands.TestCommand(*shouldTestPrevious)
 	case "submit":
-		return commands.SubmitCommand()
+		submitCmd := flag.NewFlagSet("submit", flag.ExitOnError)
+		msgShort := submitCmd.String("m", "", "commit message")
+		msgLong  := submitCmd.String("message", "", "commit message")
+		submitCmd.Parse(flag.Args()[1:])
+		if submitCmd.NArg() > 0 {
+			red := color.New(color.FgRed).SprintFunc()
+			fmt.Fprintf(os.Stderr, "%s\n", red("Error: custom commit message must be passed using -m or --message"))
+			os.Exit(1)
+		}
+		msg := *msgShort
+		if msg == "" {
+			msg = *msgLong
+		}
+		if msg == "" {
+			msg = "codecrafters submit [skip ci]"
+		}
+    	return commands.SubmitCommand(msg)
 	case "task":
 		taskCmd := flag.NewFlagSet("task", flag.ExitOnError)
 		stageSlug := taskCmd.String("stage", "", "view instructions for a specific stage (slug, +N, or -N)")

--- a/cmd/codecrafters/main.go
+++ b/cmd/codecrafters/main.go
@@ -25,6 +25,7 @@ USAGE
 
 EXAMPLES
   $ codecrafters submit            # Commit changes & run tests
+  $ codecrafters submit -m "msg"   # Commit changes & run tests with a custom commit message
   $ codecrafters test              # Run tests without committing changes
   $ codecrafters test --previous   # Run tests for all previous stages and the current stage without committing changes
 
@@ -77,28 +78,28 @@ func run() error {
 	switch cmd {
 	case "test":
 		testCmd := flag.NewFlagSet("test", flag.ExitOnError)
-		shouldTestPrevious := testCmd.Bool("previous", false, "run tests for the current stage and all previous stages in ascending order")
+		shouldTestPrevious := testCmd.Bool("previous", false, "Run tests for all previous stages and the current stage without committing changes")
 		testCmd.Parse(flag.Args()[1:]) // parse the args after the test command
 
 		return commands.TestCommand(*shouldTestPrevious)
 	case "submit":
 		submitCmd := flag.NewFlagSet("submit", flag.ExitOnError)
-		msgShort := submitCmd.String("m", "", "commit message")
-		msgLong  := submitCmd.String("message", "", "commit message")
+
+		var commitMessage string
+		defaultCommitMessage := "codecrafters submit"
+		usage := "Commit changes & run tests with a custom commit message"
+		submitCmd.StringVar(&commitMessage, "m", defaultCommitMessage, usage)
+		submitCmd.StringVar(&commitMessage, "message", defaultCommitMessage, usage)
+
 		submitCmd.Parse(flag.Args()[1:])
 		if submitCmd.NArg() > 0 {
-			red := color.New(color.FgRed).SprintFunc()
-			fmt.Fprintf(os.Stderr, "%s\n", red("Error: custom commit message must be passed using -m or --message"))
-			os.Exit(1)
+			return fmt.Errorf("Unexpected arguments: use -m or --message to set a custom commit message.")
 		}
-		msg := *msgShort
-		if msg == "" {
-			msg = *msgLong
+		if commitMessage == "" {
+			return fmt.Errorf("Cannot submit with an empty commit message.")
 		}
-		if msg == "" {
-			msg = "codecrafters submit [skip ci]"
-		}
-    	return commands.SubmitCommand(msg)
+
+		return commands.SubmitCommand(commitMessage + " [skip ci]")
 	case "task":
 		taskCmd := flag.NewFlagSet("task", flag.ExitOnError)
 		stageSlug := taskCmd.String("stage", "", "view instructions for a specific stage (slug, +N, or -N)")

--- a/internal/commands/submit.go
+++ b/internal/commands/submit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-func SubmitCommand(message string) (err error) {
+func SubmitCommand(commitMessage string) (err error) {
 	utils.Logger.Debug().Msg("submit command starts")
 
 	defer func() {
@@ -70,7 +70,7 @@ func SubmitCommand(message string) (err error) {
 	}
 
 	utils.Logger.Debug().Msgf("committing changes to %s", defaultBranchName)
-	commitSha, err := commitChanges(repoDir, message)
+	commitSha, err := commitChanges(repoDir, commitMessage)
 	if err != nil {
 		return fmt.Errorf("commit changes: %w", err)
 	}

--- a/internal/commands/submit.go
+++ b/internal/commands/submit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-func SubmitCommand() (err error) {
+func SubmitCommand(message string) (err error) {
 	utils.Logger.Debug().Msg("submit command starts")
 
 	defer func() {
@@ -70,8 +70,7 @@ func SubmitCommand() (err error) {
 	}
 
 	utils.Logger.Debug().Msgf("committing changes to %s", defaultBranchName)
-
-	commitSha, err := commitChanges(repoDir, "codecrafters submit [skip ci]")
+	commitSha, err := commitChanges(repoDir, message)
 	if err != nil {
 		return fmt.Errorf("commit changes: %w", err)
 	}


### PR DESCRIPTION
This PR adds support for custom commit messages in codecrafters submit.

Users can now pass a message using -m / --message:

codecrafters submit -m "commit message"

This change is inspired by a user discussion: https://github.com/codecrafters-io/cli/issues/41#issue-2824632801
. I also encountered the same limitation while using the CLI.

Open to feedback and happy to make any changes if needed.
