### PR TITLE
Improve error messages to clarify download failures

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -34,7 +34,7 @@ try {
     try {
         Invoke-WebRequest -Uri $DownloadUrl -OutFile $TarGzPath -UseBasicParsing
     } catch {
-        Write-Host "error: your platform and architecture (windows-$Arch) is unsupported."
+        Write-Host "error: failed to download binary. This may be due to an unsupported platform (windows-$Arch) or a network issue."
         exit 1
     }
 

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ echo -e "${MUTED}" # Muted progress bar
 HTTP_CODE=$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
 if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -gt 299 ]; then
 	echo -e "${NC}"
-	echo "error: your platform and architecture (${PLATFORM}-${ARCH}) is unsupported."
+	echo "error: failed to download binary (HTTP $HTTP_CODE). This may be due to an unsupported platform (${PLATFORM}-${ARCH}) or a network issue."
 	exit 1
 fi
 


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3295119886/12685?viewId=8414074

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates user-facing installer error messages, with no behavioral changes to download/extract/install logic.
> 
> **Overview**
> Improves installer diagnostics by updating the download-failure message in both `install.sh` and `install.ps1` to clarify that failures can be caused by either an unsupported platform/architecture or a network issue, and (on Unix) includes the HTTP status code for easier debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06036ea6840af947233fa126eefb60568529b895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->